### PR TITLE
Add unbounded_cast as well as ETS-per-worker

### DIFF
--- a/src/sidejob_worker.erl
+++ b/src/sidejob_worker.erl
@@ -106,7 +106,7 @@ init([ResName, Id, ETS, StatsName, Mod]) ->
                            width=Width,
                            limit=Limit,
                            reporter=StatsName},
-            ets:insert(ETS, [{Id - 1, 0}, {{full, Id - 1}, 0}]),
+            ets:insert(ETS, [{usage,0}, {full,0}]),
             {ok, State};
         Other ->
             Other
@@ -198,7 +198,7 @@ tick(State=#state{id=Id, reporter=Reporter}) ->
     sidejob_resource_stats:report(Reporter, Id, Usage, In, Out),
     State2.
 
-update_usage(State=#state{id=Id, ets=ETS, width=Width, limit=Limit}) ->
+update_usage(State=#state{ets=ETS, width=Width, limit=Limit}) ->
     Usage = current_usage(State),
     Full = case Usage >= (Limit div Width) of
                true ->
@@ -206,8 +206,8 @@ update_usage(State=#state{id=Id, ets=ETS, width=Width, limit=Limit}) ->
                false ->
                    0
            end,
-    ets:insert(ETS, [{Id-1, Usage},
-                     {{full, Id-1}, Full}]),
+    ets:insert(ETS, [{usage, Usage},
+                     {full, Full}]),
     State.
 
 current_usage(#state{usage=default}) ->

--- a/src/sidejob_worker_sup.erl
+++ b/src/sidejob_worker_sup.erl
@@ -21,7 +21,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/5]).
+-export([start_link/4]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -30,22 +30,22 @@
 %%% API functions
 %%%===================================================================
 
-start_link(Name, NumWorkers, ETS, StatsName, Mod) ->
+start_link(Name, NumWorkers, StatsName, Mod) ->
     NameBin = atom_to_binary(Name, latin1),
     RegName = binary_to_atom(<<NameBin/binary, "_worker_sup">>, latin1),
     supervisor:start_link({local, RegName}, ?MODULE,
-                          [Name, NumWorkers, ETS, StatsName, Mod]).
+                          [Name, NumWorkers, StatsName, Mod]).
 
 %%%===================================================================
 %%% Supervisor callbacks
 %%%===================================================================
 
-init([Name, NumWorkers, ETS, StatsName, Mod]) ->
+init([Name, NumWorkers, StatsName, Mod]) ->
     Children = [begin
                     WorkerName = sidejob_worker:reg_name(Name, Id),
                     {WorkerName,
                      {sidejob_worker, start_link,
-                      [WorkerName, Name, Id, ETS, StatsName, Mod]},
+                      [WorkerName, Name, Id, WorkerName, StatsName, Mod]},
                      permanent, 5000, worker, [sidejob_worker]}
                 end || Id <- lists:seq(1, NumWorkers)],
     {ok, {{one_for_one, 10, 10}, Children}}.


### PR DESCRIPTION
This pull-request consists of two changes to sidejob.

First, this pull-request adds `sidejob:unbounded_cast` that provides the parallel worker capabilities of sidejob without the rate limiting (in cases where rate limiting overhead is too high).

Second, this pull-request changes sidejob from using a single ETS table with different keys representing each worker, to using a single ETS table per worker with static keys. The intention is to ensure that false lock conflicts never occurs.

Specifically, the original design used a concurrency optimized table hoping that accesses to disjoint keys would hit disjoint locks. In a concurrency optimized table, BEAM breaks a table up into multiple segments that each have their own lock. Keys mapping to different segments therefore hit different locks. Unfortunately, there is no guarantee that two keys map to separate, rather than the same, segment. Likewise, in R15 there are only 16 such locks per table; with R16 increasing this to 64 per tables.

This change allows sidejob to provide stronger guarantees about lock conflicts without worrying about internal BEAM details. The expense is additional memory overhead. A minor bonus is that this change allows the keys used to access the ETS tables to be static atoms. In BEAM, atoms bypass the normal hash logic when used as ETS keys.
