### PR TITLE
Make sidejob work with Exometer

### DIFF
--- a/priv/sidejob.schema
+++ b/priv/sidejob.schema
@@ -1,0 +1,4 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%% @doc Exometer metrics
+{mapping, "exometer.template.sidejob.module", "exometer.defaults",
+ [{default, "sidejob_stat"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,4 +3,4 @@
 {eunit_opts, [verbose]}.
 {edoc_opts, [{preprocess, true}]}.
 {xref_checks, [undefined_function_calls]}.
-{deps, []}.
+{deps, [{exometer,".*",{git,"git://github.com/Feuerlabs/exometer.git",{branch,"master"}}}]}.

--- a/src/sidejob_resource_sup.erl
+++ b/src/sidejob_resource_sup.erl
@@ -73,7 +73,7 @@ init([Name, Mod]) ->
                                   public,
                                   {read_concurrency,true},
                                   {write_concurrency,true}]),
-    sidejob_resource_stats:init_stats(StatsTab),
+    sidejob_resource_stats:init_stats(Name, StatsTab),
 
     WorkerSup = {sidejob_worker_sup,
                  {sidejob_worker_sup, start_link,

--- a/src/sidejob_stat.erl
+++ b/src/sidejob_stat.erl
@@ -24,7 +24,7 @@
 
 -export([behaviour/0,
 	 new/3, delete/3, get_value/4, update/4, reset/3,
-	 sample/3, get_datapoints/3, setopts/4]).
+	 sample/3, get_datapoints/3, setopts/3]).
 
 -record(stat, {rejected = 0,
                in_sum   = 0,
@@ -92,4 +92,4 @@ get_datapoints(_, _, _) ->
      max_out_rate_60s, usage_total, rejected_total,
      avg_in_rate_total, max_in_rate_total, avg_out_rate_total].
 
-setopts(_, _, _, _) -> {error, not_supported}.
+setopts(_, _, _) -> ok.

--- a/src/sidejob_stat.erl
+++ b/src/sidejob_stat.erl
@@ -22,7 +22,8 @@
 
 -behaviour(exometer_entry).
 
--export([new/3, delete/3, get_value/4, update/4, reset/3,
+-export([behaviour/0,
+	 new/3, delete/3, get_value/4, update/4, reset/3,
 	 sample/3, get_datapoints/3, setopts/4]).
 
 -record(stat, {rejected = 0,
@@ -34,6 +35,9 @@
 
 -define(ADD(Field, Value), Field = Stat#stat.Field + Value).
 -define(MAX(Field, Value), Field = max(Stat#stat.Field, Value)).
+
+behaviour() ->
+    entry.
 
 new() ->
     #stat{}.


### PR DESCRIPTION
This PR is part of a set of PRs aimed at integrating the [Exometer](https://github.com/Feuerlabs/exometer) metrics package into Riak.

The main addition to sidejob is that the statistics maintained by sidejob are made accessible via the Exometer probe API. No overhead is introduced, apart from the slight extra cost of registering the sidejob resource as an Exometer entry at creation time. Reading the stats via Exometer requires an extra (ETS) metadata lookup, but the added benefit is that the stats are made available in a uniform way.

The metric type `sidejob` is registered as a template in Exometer, using a Cuttlefish schema entry.

Note: The option `{exometer_name, Name}` used to name the probe is provided by the caller, e.g. `riak_kv_app.erl`.
