### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.beam
 .*.swp
 ebin/sidejob.app
+.eunit

--- a/test/sidejob_eqc.erl
+++ b/test/sidejob_eqc.erl
@@ -18,7 +18,7 @@
 -record(state, {limit, width, restarts = 0, workers = []}).
 -record(worker, {pid, scheduler, queue, status = ready, cmd}).
 
--import(eqc_statem, [eq/2, tag/2]).
+-import(eqc_statem, [tag/2]).
 
 -define(RESOURCE, resource).
 -define(SLEEP, 1).
@@ -314,6 +314,7 @@ prop_par() ->
       R == ok))
   end)).
 
+-ifdef(PULSE).
 prop_pulse() ->
   ?SETUP(fun() -> N = erlang:system_flag(schedulers_online, 1),
                   fun() -> erlang:system_flag(schedulers_online, N) end end,
@@ -326,6 +327,7 @@ prop_pulse() ->
     aggregate(command_names(Cmds),
     pretty_commands(?MODULE, Cmds, HSR,
       R == ok))))).
+-endif.
 
 kill_all_pids(Pid) when is_pid(Pid) -> exit(Pid, kill);
 kill_all_pids([H|T])                -> kill_all_pids(H), kill_all_pids(T);
@@ -338,6 +340,7 @@ cleanup() ->
   % error_logger:tty(true),
   application:start(sidejob).
 
+-ifdef(PULSE).
 the_prop() -> prop_pulse().
 
 test({N, h})   -> test({N * 60, min});
@@ -375,6 +378,7 @@ pulse_instrument(File) ->
   code:purge(Mod),
   code:load_file(Mod),
   Mod.
+-endif.
 
 -ifdef(PULSE).
 eqc_test_() ->

--- a/test/sidejob_eqc.erl
+++ b/test/sidejob_eqc.erl
@@ -6,9 +6,13 @@
 
 -compile(export_all).
 
+-ifdef(EQC).
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eqc/include/eqc.hrl").
+-ifdef(PULSE).
 -include_lib("pulse/include/pulse.hrl").
+-endif.
+
 -include_lib("eunit/include/eunit.hrl").
 
 -record(state, {limit, width, restarts = 0, workers = []}).
@@ -388,3 +392,5 @@ eqc_test_() ->
      end
     }.
 -endif.
+
+-endif.                                         % top-level EQC

--- a/test/supervisor_eqc.erl
+++ b/test/supervisor_eqc.erl
@@ -190,6 +190,7 @@ prop_par() ->
       R == ok))
   end)).
 
+-ifdef(PULSE).
 prop_pulse() ->
   ?SETUP(fun() -> N = erlang:system_flag(schedulers_online, 1),
                   fun() -> erlang:system_flag(schedulers_online, N) end end,
@@ -202,6 +203,7 @@ prop_pulse() ->
     aggregate(command_names(Cmds),
     pretty_commands(?MODULE, Cmds, HSR,
       R == ok))))).
+-endif.
 
 kill_all_pids(Pid) when is_pid(Pid) -> exit(Pid, kill);
 kill_all_pids([H|T])                -> kill_all_pids(H), kill_all_pids(T);

--- a/test/supervisor_eqc.erl
+++ b/test/supervisor_eqc.erl
@@ -18,7 +18,7 @@
 -record(state, {limit, width, children = []}).
 -record(child, {pid}).
 
--import(eqc_statem, [eq/2, tag/2]).
+-import(eqc_statem, [tag/2]).
 
 -define(RESOURCE, resource).
 -define(SLEEP, 1).

--- a/test/supervisor_eqc.erl
+++ b/test/supervisor_eqc.erl
@@ -6,9 +6,13 @@
 
 -compile(export_all).
 
+-ifdef(EQC).
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eqc/include/eqc.hrl").
+-ifdef(PULSE).
 -include_lib("pulse/include/pulse.hrl").
+-endif.
+
 -include_lib("eunit/include/eunit.hrl").
 
 -record(state, {limit, width, children = []}).
@@ -245,4 +249,6 @@ eqc_test_() ->
              ?assert(eqc:quickcheck(eqc:testing_time(5, ?QC_OUT(prop_par()))))
      end
     }.
--endif
+-endif.
+
+-endif.                                         % top-level EQC


### PR DESCRIPTION
NOTE: These fixes were spurred by giddyup failure which I also reproduced locally.
- Ignore .eunit
- Remove `eq/2` import, it is already included in newer EQC (or at least that is my guess).
- Wrap with `-ifdef(EQC)` for those without EQC.
- Wrap PULSE stuff with `-ifdef(PULSE)`.
