### PR TITLE
Fix dialyzer warnings.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [debug_info, warnings_as_errors]}.
+{erl_opts, [debug_info, warnings_as_errors, warn_untyped_records]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/src/sidejob.erl
+++ b/src/sidejob.erl
@@ -134,7 +134,11 @@ is_available(WorkerETS, Limit, Worker) ->
             false;
         0 ->
             Value = ets:update_counter(ETS, usage, 1),
-            [ ets:insert(ETS, {full, 1}) || Value >= Limit ],
+            if Value >= Limit ->
+                    ets:insert(ETS, {full, 1});
+               true ->
+                    ok
+            end,
             true
     end.
 

--- a/src/sidejob_supervisor.erl
+++ b/src/sidejob_supervisor.erl
@@ -57,7 +57,7 @@ start_child(Name, Mod, Fun, Args) ->
             Other
     end.
 
--spec spawn(resource(), function()) -> {ok, pid()} | {error, overload}.
+-spec spawn(resource(), function() | {module(), atom(), [term()]}) -> {ok, pid()} | {error, overload}.
 spawn(Name, Fun) ->
     case sidejob:call(Name, {spawn, Fun}, infinity) of
         overload ->
@@ -66,7 +66,7 @@ spawn(Name, Fun) ->
             Other
     end.
 
--spec spawn(resource(), module(), atom(), term()) -> {ok, pid()} |
+-spec spawn(resource(), module(), atom(), [term()]) -> {ok, pid()} |
                                                      {error, overload}.
 spawn(Name, Mod, Fun, Args) ->
     ?MODULE:spawn(Name, {Mod, Fun, Args}).

--- a/src/sidejob_worker.erl
+++ b/src/sidejob_worker.erl
@@ -54,9 +54,9 @@
                 mod             :: module(),
                 modstate        :: term(),
                 usage           :: custom | default,
-                last_mq_len = 0 :: pos_integer(),
-                enqueue     = 0 :: pos_integer(),
-                dequeue     = 0 :: pos_integer()}).
+                last_mq_len = 0 :: non_neg_integer(),
+                enqueue     = 0 :: non_neg_integer(),
+                dequeue     = 0 :: non_neg_integer()}).
 
 %%%===================================================================
 %%% API


### PR DESCRIPTION
This addresses all warnings in http://giddyup.basho.com/#/projects/smoke-tests/scorecards/86/86-1860-sidejob:dialyzer-ubuntu-1204-64/40972/artifacts/621112
