### PR TITLE
Don't shut down sidejob_supervisor upon receiving a spurious EXIT.

### DIFF
--- a/src/sidejob_supervisor.erl
+++ b/src/sidejob_supervisor.erl
@@ -120,17 +120,17 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info({'EXIT', Pid, Reason}, State=#state{children=Children,
+handle_info({'EXIT', Pid, _Reason}, State=#state{children=Children,
                                                 died=Died}) ->
-    case sets:is_element(Pid, Children) of
+    State2 = case sets:is_element(Pid, Children) of
         true ->
             Children2 = sets:del_element(Pid, Children),
             Died2 = Died + 1,
-            State2 = State#state{children=Children2, died=Died2},
-            {noreply, State2};
+            State#state{children=Children2, died=Died2};
         false ->
-            {stop, Reason, State}
-    end;
+            State
+    end,
+    {noreply, State2};
 
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/test/supervisor_test.erl
+++ b/test/supervisor_test.erl
@@ -1,0 +1,21 @@
+-module(supervisor_test).
+-export([fail_to_start_link/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(RESOURCE, supervisor_test_resource).
+
+% Setup a sidejob resource and start a child that links to the parent but doesn't return {ok, Pid}.
+% The supervisor should not shut down.
+spurious_exit_test() ->
+  {ok, _} = application:ensure_all_started(sidejob),
+  {ok, _} = sidejob:new_resource(?RESOURCE, sidejob_supervisor, 5, 1),
+  {WorkerReg} = ?RESOURCE:workers(),
+  WorkerPid = whereis(WorkerReg),
+  ?assert(is_process_alive(WorkerPid)),
+  {ok, undefined} = sidejob_supervisor:start_child(?RESOURCE, ?MODULE, fail_to_start_link, []),
+  sidejob_supervisor:which_children(?RESOURCE), % wait for sidejob_supervisor to process the EXIT
+  ?assert(is_process_alive(WorkerPid)).
+
+fail_to_start_link() ->
+  spawn_link(fun () -> ok end),
+  ignore.


### PR DESCRIPTION
When sidejob_supervisor received {'EXIT', Pid, Reason} it checked if
the EXIT signal was sent by one of its children, if so it removed the
child from its state.

If the EXIT came from another Pid sidejob_supervisor terminated, I
guess because of the assumption that in that case Pid was the parent
telling sidejob_supervisor to shut down. Actually this case is already
handled in gen_server itself.

The problem was that if starting a child using apply(Mod, Fun, Args)
failed but a child process was already spawned and linked (which is
what happens in i.e. gen_server:start_link) sidejob_supervisor would
receive an EXIT signal but because the pid wasn't registered as one of
its children it then terminated.

This commit changes behavior to be in accordance with OTP's supervisor
which just ignores EXIT signals from unknown Pids, and delegates
handling the EXIT from its parent to gen_server.
